### PR TITLE
Fix rtc driver removal and make library shared

### DIFF
--- a/lib/mk/gtest.mk
+++ b/lib/mk/gtest.mk
@@ -11,5 +11,6 @@ INC_DIR += $(GTEST_DIR)/include
 INC_DIR += $(GTEST_DIR)/include/internal
 
 LIBS += libc libm stdcxx
+SHARED_LIB = yes
 
 CC_CXX_WARN_STRICT =

--- a/run/gtest-samples.run
+++ b/run/gtest-samples.run
@@ -57,7 +57,6 @@ build_boot_image {
 	core init ld.lib.so
 	timer
 	libc.lib.so vfs.lib.so libm.lib.so posix.lib.so stdcxx.lib.so
-	rtc_drv
 	gtest-samples
 }
 

--- a/run/gtest-samples.run
+++ b/run/gtest-samples.run
@@ -57,7 +57,7 @@ build_boot_image {
 	core init ld.lib.so
 	timer
 	libc.lib.so vfs.lib.so libm.lib.so posix.lib.so stdcxx.lib.so
-	gtest-samples
+	gtest.lib.so gtest-samples
 }
 
 append qemu_args " -nographic "

--- a/run/gtest.run
+++ b/run/gtest.run
@@ -65,7 +65,6 @@ build_boot_image {
 	core init ld.lib.so
 	timer ram_fs
 	libc.lib.so vfs.lib.so libm.lib.so posix.lib.so stdcxx.lib.so
-	rtc_drv
 	gtest
 }
 

--- a/run/gtest.run
+++ b/run/gtest.run
@@ -65,7 +65,7 @@ build_boot_image {
 	core init ld.lib.so
 	timer ram_fs
 	libc.lib.so vfs.lib.so libm.lib.so posix.lib.so stdcxx.lib.so
-	gtest
+	gtest.lib.so gtest
 }
 
 append qemu_args " -nographic "


### PR DESCRIPTION
This is a fixup to #187 - I forgot to remove rtc_drv from the boot image. This only became apparent after a fresh CI run. My bad!

It also makes the library shared. I don't know why it was static in the first place. The static library causes trouble on ARM64 (tested with foc/rpi3) during the final link of the binary:

```sh
    LINK     gtest
/usr/local/genode/tool/19.05/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld: /home/senier/Documents/Componolit_GmbH/Devel/src/gart/genode-master/build/arm_v8a/var/libcache/gtest/gtest.lib.a(gtest-all.o)(.data.rel.ro._ZTIN7testing8internal26GoogleTestFailureExceptionE[_ZTIN7testing8internal26GoogleTestFailureExceptionE]+0x10): unresolvable R_AARCH64_ABS64 relocation against symbol `_ZTISt13runtime_error'
/usr/local/genode/tool/19.05/bin/../lib/gcc/aarch64-none-elf/8.3.0/../../../../aarch64-none-elf/bin/ld: final link failed: nonrepresentable section on output
collect2: error: ld returned 1 exit status
```

As I'm not interested in gtest being static, making it shared fixes that issue for me. Maybe there is an underlying issue with ARM64, though. The issue can be reproduced by commenting out `SHARED_LIB = yes` in `repos/world/lib/mk/gtest.mk` and building the test cases for foc/rpi:

```
$ make run/gtest KERNEL=foc BOARD=rpi3
```