### PR TITLE
jdk: support ARMv7 and x86_64 only in java.run

### DIFF
--- a/lib/mk/java.inc
+++ b/lib/mk/java.inc
@@ -3,7 +3,6 @@ SHARED_LIB    = yes
 JDK_BASE      = $(call select_from_ports,jdk)/src/app/jdk/jdk/src/java.base
 JDK_GENERATED = $(call select_from_ports,jdk_generated)/src/app/jdk
 JAVA_BASE     = $(JDK_BASE)/share/native/libjava
-VERIFY_BASE   = $(JDK_BASE)/share/native/libverify
 
 SRC_C  = $(notdir $(wildcard $(JAVA_BASE)/*.c))
 SRC_C += unix/native/libjava/canonicalize_md.c \
@@ -19,7 +18,6 @@ SRC_C += unix/native/libjava/canonicalize_md.c \
          unix/native/libjava/TimeZone_md.c \
          unix/native/libjava/UnixFileSystem_md.c
 
-SRC_C += check_format.c check_code.c
 SRC_C += math_genode.c
 
 
@@ -38,7 +36,6 @@ INC_DIR += $(REP_DIR)/src/app/jdk/lib/include \
            $(JDK_BASE)/unix/native/libjava
 
 vpath %.c $(JAVA_BASE)
-vpath %.c $(VERIFY_BASE)
 vpath %.c $(JDK_BASE)
 vpath %.c $(REP_DIR)/src/app/jdk/lib/java
 

--- a/lib/mk/jvm.inc
+++ b/lib/mk/jvm.inc
@@ -1,4 +1,4 @@
-LIBS         = stdcxx jzip jimage nio jnet libc libc_pipe
+LIBS         = stdcxx jzip jimage nio jnet libc libc_pipe verify
 SHARED_LIB   = yes
 HOTSPOT_BASE = $(call select_from_ports,jdk)/src/app/jdk/hotspot/src
 

--- a/lib/mk/verify.mk
+++ b/lib/mk/verify.mk
@@ -1,0 +1,17 @@
+LIBS        = libc
+SHARED_LIB  = yes
+JDK_BASE    = $(call select_from_ports,jdk)/src/app/jdk/jdk/src/java.base
+VERIFY_BASE = $(JDK_BASE)/share/native/libverify
+
+SRC_C += check_format.c check_code.c
+
+include $(REP_DIR)/lib/mk/jdk_version.inc
+
+INC_DIR += $(JDK_BASE)/share/native/include \
+           $(JDK_BASE)/share/native/libjava \
+           $(JDK_BASE)/unix/native/include \
+           $(JDK_BASE)/unix/native/libjava
+
+vpath %.c $(VERIFY_BASE)
+
+# vi: set ft=make :

--- a/recipes/src/jdk/content.mk
+++ b/recipes/src/jdk/content.mk
@@ -1,4 +1,4 @@
-LIB_MK_FILES := java.inc jdk_version.inc jimage.mk jli.mk \
+LIB_MK_FILES := java.inc jdk_version.inc jimage.mk jli.mk verify.mk \
                 jnet.mk jvm.inc jzip.mk management.mk nio.mk \
                $(foreach SPEC,x86_64 arm, \
                 spec/$(SPEC)/java.mk spec/$(SPEC)/jvm.mk) \

--- a/run/java.run
+++ b/run/java.run
@@ -1,3 +1,9 @@
+
+if {![have_spec x86_64] && ![have_spec arm_v7]} {
+	puts "Unsupported platform. Valid are x86_64 and arm_v7 platforms."
+	exit 0
+}
+
 set build_components {
 	core init
 	timer


### PR DESCRIPTION
needed for nightly testing.