### PR TITLE
Bugfix for iperf_internal on real hardware

### DIFF
--- a/run/iperf_internal.run
+++ b/run/iperf_internal.run
@@ -115,6 +115,7 @@ set config {
 							<service name="ROM"/>
 							<service name="CPU"/>
 							<service name="PD"/>
+							<service name="RM"/>
 							<service name="Nic"/>
 						</parent-provides>					
 						<start name="iperf_client" caps="320">


### PR DESCRIPTION
When ran in qemu there was no problem but while running on real hardware the missing RM service was complained about.