### PR TITLE
scip: build still as c++17

### DIFF
--- a/lib/mk/scip.mk
+++ b/lib/mk/scip.mk
@@ -2,6 +2,7 @@ SCIP_DIR = $(call select_from_ports,scip)/src/lib/scip/src
 LIBS    += libc zlib soplex
 INC_DIR += $(SCIP_DIR)
 INC_DIR += $(REP_DIR)/src/lib/scip
+CC_CXX_OPT_STD = -std=c++17
 
 # plugin files
 SRC_C    =       scip/branch_allfullstrong.c \

--- a/lib/mk/soplex.mk
+++ b/lib/mk/soplex.mk
@@ -2,6 +2,8 @@ SOPLEX_DIR = $(call select_from_ports,soplex)/src/lib/soplex/src/
 LIBS    += libc zlib gmp stdcxx libm
 INC_DIR += $(SOPLEX_DIR)
 INC_DIR += $(REP_DIR)/src/lib/soplex
+CC_CXX_OPT_STD = -std=c++17
+
 SRC_CC   = 	changesoplex.cpp \
 			clufactor.cpp \
 			didxset.cpp \


### PR DESCRIPTION
as the ported versions of soplex and scip are quite old and can't be built with c++20 we define for this two libraries c++17 as the to be used standard.

This is of course just a workaround, the clean (but more labourios) solution is to upgrade the libraries to a more current version.