### PR TITLE
add rtc to app, fix incorrect rtc const and fix err in sample golang app causing panic

### DIFF
--- a/run/go_app.run
+++ b/run/go_app.run
@@ -13,6 +13,8 @@ set arena_mem_size "1610612736"
 # pipe is mandatory for netpoll which is compiled now into libgo bu default
 set need_pipe 1
 
+set use_rtc 1
+
 # TARGET= from target.mk
 set executable "go_app"
 # could be like test to refer make target test/go_app
@@ -31,12 +33,28 @@ set conf_ld_verbose "yes"
 
 # build section
 set build_components {
-	core init timer lib/ld lib/libc lib/libm lib/posix lib/stdcxx lib/vfs
+	core init timer lib/ld lib/libc lib/libm lib/posix lib/stdcxx lib/vfs drivers/rtc
 }
 
 lappend build_components "$executable_place/$executable"
 
 append_if $need_pipe build_components { lib/vfs_pipe }
+
+set depot_pkgs { }
+lappend depot_pkgs [depot_user]/src/[base_src]
+lappend depot_pkgs [depot_user]/src/init
+
+if [have_board linux] {
+        lappend_if $use_rtc depot_pkgs [depot_user]/src/linux_rtc_drv
+} else {
+        if [have_board pc] {
+                lappend_if $use_rtc depot_pkgs [depot_user]/src/rtc_drv
+        } else  {
+                lappend_if $use_rtc depot_pkgs [depot_user]/src/dummy_rtc_drv
+        }
+}
+
+import_from_depot $depot_pkgs
 
 build $build_components
 
@@ -73,6 +91,19 @@ append config {
 	</start>
 }
 
+append_if [expr [have_board linux] && $use_rtc] config {
+	<start name="linux_rtc_drv" caps="200" ld="no">}
+append_if [expr [have_board pc] && $use_rtc] config {
+	<start name="rtc_drv" caps="200">}
+append_if [expr ![have_board pc] && ![have_board linux] && $use_rtc] config {
+	<start name="dummy_rtc_drv" caps="200">}
+
+append_if $use_rtc  config {
+		<resource name="RAM" quantum="6M"/>
+		<provides> <service name="Rtc"/> </provides>
+	</start>
+}
+
 # main golang executable
 append config {
 	<start name="} $executable {" caps="} $executable_caps {">
@@ -80,7 +111,7 @@ append config {
 		<config verbose="} $conf_verbose {"  ld_verbose="} $conf_ld_verbose {">
 			<arg value="} $executable {" />
 			<vfs>
-				<dir name="dev"> <log/> </dir>
+				<dir name="dev"> <log/> <inline name="rtc">2020-01-01 00:00</inline> </dir>
 }
 
 # add every library/binaries (mandatory for golang stack unwind)
@@ -104,6 +135,8 @@ append_if $need_pipe config {
 append config {
 			</vfs>
 				<libc stdout="/dev/log" stderr="/dev/log"
+				rtc="/dev/rtc"
+
 }
 
 append_if $need_pipe config {

--- a/src/lib/libgo/newsrc.patch
+++ b/src/lib/libgo/newsrc.patch
@@ -475,7 +475,7 @@ diff -uwBrN gcc.libgo_etalon/libgo/go/runtime/os_genode.go libgo-27ecc7632f6a601
 +func semasleep(ns int64) int32 {
 +	_m_ := getg().m
 +	if ns >= 0 {
-+		const CLOCK_REALTIME int64 = 9
++		const CLOCK_REALTIME int64 = 0
 +		var ts timespec
 +
 +		if clock_gettime(CLOCK_REALTIME, &ts) != 0 {

--- a/src/test/go_app/README.golang
+++ b/src/test/go_app/README.golang
@@ -47,7 +47,7 @@ export CC=genode-$ARCH-gcc
 export RANLIB=genode-$ARCH-ranlib
 	execute file above like '. pathes.sh'
 	correct if need begining of build/x86_64/etc/build.conf and uncomment 
-	libports, ports, world, pc, dde_linux repos inside:
+	libports, ports, world, pc, dde_linux, gems repos inside:
 	GENODE_DIR  := <your genode dir>
 	BASE_DIR    := $(GENODE_DIR)/repos/base
 	CONTRIB_DIR := $(GENODE_DIR)/contrib

--- a/src/test/go_app/main.go
+++ b/src/test/go_app/main.go
@@ -137,7 +137,7 @@ type Customer struct {
 }
 
 func (c *Customer) String() string {
-	return fmt.Sprintf("%p", c)[7:]
+	return fmt.Sprintf("%7p", c)[7:]
 }
 
 func NewBarber() (b *Barber) {


### PR DESCRIPTION
seems that now rtc driver mandatory to clock_gettime() in libc, add this to run file, and fix constant value from CLOCK_REALTIME_PRESIZE to CLOCK_REALTIME.

Fix out-of-bounds error in sample go application while printing a pointer.